### PR TITLE
Upgraded Umbraco OpenID Connect example package to Umbraco 12.2.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Contributions:
 - 2023-10-18 - [Nurhak Kaya](https://github.com/NurhakKaya) - [Blog post](https://www.nurhakkaya.com/2023/10/umbraco-cms-kaynak-koduna-katk-icin.html) - "Turkish blog post about Steps to contribute to Umbraco CMS source code"
 - 2023-10-19 - [Owain Williams](https://github.com/OwainWilliams) - Speaker "Why you should give Umbraco CMS a try" at .Net Glasgow meetup
 - 2023-10-20 - [Nurhak Kaya](https://github.com/NurhakKaya) - [Blog post](https://umbraco.com/blog/) - "Unlocking Efficiency and Flexibility with Umbraco Cloud" - To be published by Eleftheria Tsatsi at Umbraco HQ in November 2023 on Umbraco's website
+- 2023-10-20 - [Jeroen Breuer](https://github.com/jbreuer) -  [Upgraded Umbraco OpenID Connect example package to Umbraco 12.2.0.](https://github.com/jbreuer/Umbraco-OpenIdConnect-Example/commit/0887d65058694fa4d48c99d3d58b8477175b918b) - Tested if OpenID Connect works on V12.2
 
 ## New Umbraco packages
 


### PR DESCRIPTION
I'm the developer of the [Umbraco OpenID Connect example package](https://github.com/jbreuer/Umbraco-OpenIdConnect-Example#umbraco-openid-connect-example-package). I always upgrade to the newest version of Umbraco because in the past some versions broke the OpenID Connect implementation.