### PR TITLE
Upgraded Umbraco OpenID Connect example package to Umbraco 12.3.0-rc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Contributions:
 - 2023-10-20 - [Jeroen Breuer](https://github.com/jbreuer) -  [Upgraded Umbraco OpenID Connect example package to Umbraco 12.2.0.](https://github.com/jbreuer/Umbraco-OpenIdConnect-Example/commit/0887d65058694fa4d48c99d3d58b8477175b918b) - Tested if OpenID Connect works on V12.2
 - 2023-10-24 - [Owain Williams](https://github.com/OwainWilliams) & [Tom Madden](https://github.com/TwoMoreThings) - Host the Edinburgh Umbraco Users Group meetup which was a [Hacktoberfest special](https://www.meetup.com/edinburgh-umbraco-users-group/events/296507496/).
 - 2023-10-26 - [Corné Hoskam](https://github.com/cornehoskam) - [Blog posts](https://cornehoskam.com/posts/how-to-include-appsettings-schema-json-files-in-umbraco-packages) - "How to Include appsettings-schema.json Files in Umbraco Packages"
+- 2023-10-27 - [Jeroen Breuer](https://github.com/jbreuer) -  [Upgraded Umbraco OpenID Connect example package to Umbraco 12.3.0-rc.](https://github.com/jbreuer/Umbraco-OpenIdConnect-Example/commit/a22dba9c3e44dc4e30b0eec641b6bcc541382736) - Tested if OpenID Connect works on V12.3-rc
 
 ## New Umbraco packages
 


### PR DESCRIPTION
Similar to this PR: https://github.com/umbraco/HacktoberfestActivityLog/pull/67

I tested if the the [External login providers](https://docs.umbraco.com/umbraco-cms/reference/security/external-login-providers) feature still works on Umbraco 12.3.0-rc.