### PR TITLE
Create Package: Groups to Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Contributions:
 - 2024-10-11 - Søren Kottal - Released two new packages - [Schemex Exporter](https://marketplace.umbraco.com/package/umbraco.community.schemex.exporter) and [Schemex Importer](https://marketplace.umbraco.com/package/umbraco.community.schemex.importer)
 - 2024-10-12 - Søren Kottal - Released v5 🫨 of [Full Text Search](https://marketplace.umbraco.com/package/our.umbraco.fulltextsearch) for Umbraco 14 (and 15)
 - 2024-10-15 - Kaspar Boel Kjeldsen - Released v3 of [Knowit.Umbraco.InstantBlockPreview](https://marketplace.umbraco.com/package/knowit.umbraco.instantblockpreview) Supporting the new "Block Level Variance" in the generated previews.
+- 2024-10-23  - James Carter - Released [Groups to Tabs](https://marketplace.umbraco.com/package/jcdcdev.umbraco.groupstotabs) for Umbraco 14 & 15
 
 ## Sponsor a GitHub repo
 


### PR DESCRIPTION
I created a new package that converts `Groups` to `Tabs` for all property groups 😀 a handy utility when migrating old websites that need a quick "tidy up".

<details>
<summary>
Screenshots
</summary>

![image](https://github.com/user-attachments/assets/c176113c-95be-4dec-9af5-980ef05a8a0f)

![image](https://github.com/user-attachments/assets/e167c66e-56f1-4c2d-9a25-57f442609ee7)

</details

Also, does upgrading any of my existing packages to v15 count as a contribution? For example [Cloudflare Media Cache](https://github.com/jcdcdev/jcdcdev.Umbraco.CloudflareMediaCache/pull/39) - [15.0.0-alpha0001](https://www.nuget.org/packages/jcdcdev.Umbraco.CloudflareMediaCache/15.0.0-alpha0001)
