### PR TITLE
Added blog post - How to deploy Umbraco using Web Deploy from Azure DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Contributions:
 - 2024-10-30 - Aaron Sadler - Blog Post - [How to deploy Umbraco using Web Deploy from GitHub Actions](https://umbhost.net/blog/2024/10/how-to-deploy-umbraco-using-web-deploy-from-github-actions)
 - 2024-10-30 - Carl Sargunar - Organise a meetup and also speaking at that meetup - [https://www.meetup.com/dotnetsouthwest/events/303746106/](https://www.meetup.com/dotnetsouthwest/events/303746106/)
 - 2024-10-30 - Adam Prendergast - Speaking at .Net South West meetup in the UK on Astro & Umbraco Content Delivery API - [https://www.meetup.com/dotnetsouthwest/events/303746106/](https://www.meetup.com/dotnetsouthwest/events/303746106/)
+- 2024-10-31 - Aaron Sadler - Blog Post - [How to deploy Umbraco using Web Deploy from Azure DevOps](https://umbhost.net/blog/2024/10/how-to-deploy-umbraco-using-web-deploy-from-azure-devops)
 - 2024-10-31 - Carl Sargunar - Speaking at a meetup about Umbraco and Maui - [https://www.meetup.com/umbracymru/events/298562662](https://www.meetup.com/umbracymru/events/298562662)
 - 2024-10-31 - Adam Prendergast - Speaking at UmbraCymru meetup about Astro & Umbraco Content Delivery API - [https://www.meetup.com/umbracymru/events/298562662](https://www.meetup.com/umbracymru/events/298562662)
 - 2024-10-21 - Bernadet Goey - Wrote a blog post about communicating with custom API endpoints in Umbraco 14 - [Communicate with a custom API endpoint in Umbraco 14 – Part 1](https://tech.ilionx.com/communicate-with-a-custom-api-endpoint-in-umbraco-14-part-1/)


### PR DESCRIPTION
Blog post will be published on 31st at 9am UK time, so will remove draft status around then

https://umbhost.net/blog/2024/10/how-to-deploy-umbraco-using-web-deploy-from-azure-devops